### PR TITLE
RELEASES: v1.3.0.0

### DIFF
--- a/LeVent/LeVent.csproj
+++ b/LeVent/LeVent.csproj
@@ -12,9 +12,9 @@
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageIcon>LeVent.png</PackageIcon>
 		<PackageIconUrl />
-		<Version>1.2</Version>
-		<AssemblyVersion>1.2.0.0</AssemblyVersion>
-		<FileVersion>1.2.0.0</FileVersion>
+		<Version>1.3</Version>
+		<AssemblyVersion>1.3.0.0</AssemblyVersion>
+		<FileVersion>1.3.0.0</FileVersion>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<PackageLicenseExpression></PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/hassanhabib/LeVent</PackageProjectUrl>
@@ -22,7 +22,7 @@
 		<RepositoryUrl>https://github.com/hassanhabib/LeVent</RepositoryUrl>
 		<RepositoryType>Github</RepositoryType>
 		<PackageTags>Events .NET</PackageTags>
-		<PackageReleaseNotes>Added Basic Events with Target Event Name</PackageReleaseNotes>
+		<PackageReleaseNotes>This release changes the target framework to .NET Standard 2.0 to increase cross-platform compatibility.</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
The change to  .NET Standard 2.0  has actually happened quite a while back, but we have not done a NuGet release for this.  Currently seeing this message trying to install package:

![image](https://github.com/hassanhabib/LeVent/assets/797750/efc5ce24-5a39-4cec-9fda-84f6c61c8878)

